### PR TITLE
Add aarch64.bash script

### DIFF
--- a/aarch64.bash
+++ b/aarch64.bash
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+cd astyle-code/AStyle/build/gcc/
+
+make clean
+
+CFLAGS="-Os" LDFLAGS="-s" make java
+
+cp bin/libastyle*.so ../../../../libastylej_aarch64.so


### PR DESCRIPTION
This compiles astyle for 64-bit ARM (AArch64). The script should run on
any native AArch64 hardware, or a chroot from an x86-64 machine using
qemu-aarch64-static to emulate the AArch64 binaries.