### PR TITLE
Add ppc64le support

### DIFF
--- a/ppc64le.bash
+++ b/ppc64le.bash
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+cd astyle-code/AStyle/build/gcc/
+
+make clean
+
+CFLAGS="-Os" LDFLAGS="-s" make java
+
+cp bin/libastyle*.so ../../../../libastylej_ppc64le.so


### PR DESCRIPTION
There are no prebuilt packages available for ppc64el (OpenPOWER) systems, despite the software working on those platforms (after some significant manual work to pull in dependencies using the correct architecture).

OpenPOWER systems are being deployed more widely, especially in education, and having an easy way to install a newer IDE version than the 1.5 version in Debian Experimental would be much appreciated.

See also arduino/Arduino#8778